### PR TITLE
Expose `PackageKit.Transaction` properties

### DIFF
--- a/lib/src/packagekit_client.dart
+++ b/lib/src/packagekit_client.dart
@@ -854,9 +854,8 @@ class PackageKitTransaction {
 
   /// Creates a PackageKit transaction from [objectPath].
   /// This is only required if accessing an existing transaction, otherwise use [PackageKitClient.createTransaction].
-  PackageKitTransaction(DBusClient bus, DBusObjectPath objectPath,
-      {DBusRemoteObject? object})
-      : _object = object ??
+  PackageKitTransaction(DBusClient bus, DBusObjectPath objectPath)
+      : _object =
             DBusRemoteObject(bus, name: _packageKitBusName, path: objectPath) {
     events = DBusSignalStream(bus,
             sender: _packageKitBusName,

--- a/lib/src/packagekit_client.dart
+++ b/lib/src/packagekit_client.dart
@@ -857,6 +857,50 @@ class PackageKitTransaction {
   final _propertiesChangedController =
       StreamController<List<String>>.broadcast();
 
+  /// The transaction role enum, e.g. update-system.
+  PackageKitRole get role =>
+      PackageKitRole.values[_properties['Role']?.asUint32() ?? 0];
+
+  /// The transaction status enum, e.g. downloading.
+  PackageKitStatus get status =>
+      PackageKitStatus.values[_properties['Status']?.asUint32() ?? 0];
+
+  /// The last package_id that was processed, e.g. hal;0.1.2;i386;fedora.
+  String get lastPackage => _properties['LastPackage']?.asString() ?? '';
+
+  /// The uid of the user that started the transaction.
+  int get uid => _properties['Uid']?.asUint32() ?? -1;
+
+  /// The percentage complete of the transaction.
+  int get percentage => _properties['Percentage']?.asUint32() ?? 0;
+
+  /// If the transaction can be cancelled.
+  bool get allowCancel => _properties['AllowCancel']?.asBoolean() ?? false;
+
+  /// If the original caller of the method is still connected to the system bus.
+  bool get callerActive => _properties['CallerActive']?.asBoolean() ?? false;
+
+  /// The amount of time elapsed during the transaction in seconds.
+  int get elapsedTime => _properties['ElapsedTime']?.asUint32() ?? 0;
+
+  /// The estimated time remaining of the transaction in seconds, or 0 if not known.
+  int get remainingTime => _properties['RemainingTime']?.asUint32() ?? 0;
+
+  /// The estimated speed of the transaction (copying, downloading, etc.) in bits per second, or 0 if not known.
+  int get speed => _properties['Speed']?.asUint32() ?? 0;
+
+  /// The number of bytes remaining to download, 0 if nothing is left to download.
+  int get downloadSizeRemaining =>
+      _properties['DownloadSizeRemaining']?.asUint64() ?? -1;
+
+  /// The flags set for this transaction, e.g. SIMULATE or ONLY_DOWNLOAD.
+  Set<PackageKitTransactionFlag> get transactionFlags =>
+      _decodeTransactionFlags(_properties['TransactionFlags']?.asUint64() ?? 0);
+
+  /// Stream of property names as they change.
+  Stream<List<String>> get propertiesChanged =>
+      _propertiesChangedController.stream;
+
   /// Creates a PackageKit transaction from [objectPath].
   /// This should not be accessed directly, use [PackageKitClient.getTransaction] to get an existing transaction, otherwise use [PackageKitClient.createTransaction].
   PackageKitTransaction(DBusClient bus, DBusObjectPath objectPath)
@@ -1259,50 +1303,6 @@ class PackageKitTransaction {
         ],
         replySignature: DBusSignature(''));
   }
-
-  /// The transaction role enum, e.g. update-system.
-  PackageKitRole get role =>
-      PackageKitRole.values[_properties['Role']?.asUint32() ?? 0];
-
-  /// The transaction status enum, e.g. downloading.
-  PackageKitStatus get status =>
-      PackageKitStatus.values[_properties['Status']?.asUint32() ?? 0];
-
-  /// The last package_id that was processed, e.g. hal;0.1.2;i386;fedora.
-  String get lastPackage => _properties['LastPackage']?.asString() ?? '';
-
-  /// The uid of the user that started the transaction.
-  int get uid => _properties['Uid']?.asUint32() ?? -1;
-
-  /// The percentage complete of the transaction.
-  int get percentage => _properties['Percentage']?.asUint32() ?? 0;
-
-  /// If the transaction can be cancelled.
-  bool get allowCancel => _properties['AllowCancel']?.asBoolean() ?? false;
-
-  /// If the original caller of the method is still connected to the system bus.
-  bool get callerActive => _properties['CallerActive']?.asBoolean() ?? false;
-
-  /// The amount of time elapsed during the transaction in seconds.
-  int get elapsedTime => _properties['ElapsedTime']?.asUint32() ?? 0;
-
-  /// The estimated time remaining of the transaction in seconds, or 0 if not known.
-  int get remainingTime => _properties['RemainingTime']?.asUint32() ?? 0;
-
-  /// The estimated speed of the transaction (copying, downloading, etc.) in bits per second, or 0 if not known.
-  int get speed => _properties['Speed']?.asUint32() ?? 0;
-
-  /// The number of bytes remaining to download, 0 if nothing is left to download.
-  int get downloadSizeRemaining =>
-      _properties['DownloadSizeRemaining']?.asUint64() ?? -1;
-
-  /// The flags set for this transaction, e.g. SIMULATE or ONLY_DOWNLOAD.
-  Set<PackageKitTransactionFlag> get transactionFlags =>
-      _decodeTransactionFlags(_properties['TransactionFlags']?.asUint64() ?? 0);
-
-  /// Stream of property names as they change.
-  Stream<List<String>> get propertiesChanged =>
-      _propertiesChangedController.stream;
 
   void _updateProperties(Map<String, DBusValue> properties) {
     _properties.addAll(properties);

--- a/lib/src/packagekit_client.dart
+++ b/lib/src/packagekit_client.dart
@@ -1413,13 +1413,12 @@ class PackageKitClient {
       }
 
       var s = DBusPropertiesChangedSignal(signal);
-      if (s.propertiesInterface == _packageKitInterfaceName) {
-        if (s.path == _root.path) {
-          _updateProperties(s.changedProperties);
-        } else {
-          var transaction = _transactions[s.path];
-          transaction?._updateProperties(s.changedProperties);
-        }
+      if (s.propertiesInterface == _packageKitInterfaceName &&
+          s.path == _root.path) {
+        _updateProperties(s.changedProperties);
+      } else if (s.propertiesInterface == _packageKitTransactionInterfaceName) {
+        var transaction = _transactions[s.path];
+        transaction?._updateProperties(s.changedProperties);
       }
     });
     _updateProperties(await _root.getAllProperties(_packageKitInterfaceName));
@@ -1430,8 +1429,8 @@ class PackageKitClient {
     var transaction = PackageKitTransaction(_bus, path);
     _transactions[path] = transaction;
 
-    transaction._updateProperties(
-        await transaction._object.getAllProperties(_packageKitInterfaceName));
+    transaction._updateProperties(await transaction._object
+        .getAllProperties(_packageKitTransactionInterfaceName));
 
     return transaction;
   }

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -2189,8 +2189,11 @@ void main() {
     addTearDown(() async => await packagekit.close());
     await packagekit.start();
 
-    var transaction = PackageKitTransaction(DBusClient(clientAddress), t.path);
-    await transaction.initialized;
+    var client = PackageKitClient(bus: DBusClient(clientAddress));
+    addTearDown(() async => await client.close());
+    await client.connect();
+
+    var transaction = await client.getTransaction(t.path);
 
     expect(transaction.role, equals(PackageKitRole.getDetails));
     expect(transaction.status, equals(PackageKitStatus.info));

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -510,6 +510,7 @@ class MockPackageKitTransaction extends DBusObject {
   void emitFinished(int exit, int runtime) {
     emitSignal('org.freedesktop.PackageKit.Transaction', 'Finished',
         [DBusUint32(exit), DBusUint32(runtime)]);
+    emitSignal('org.freedesktop.PackageKit.Transaction', 'Destroy', []);
   }
 
   void emitItemProgress(String packageId, int status, int percentage) {

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -69,29 +69,29 @@ class MockPackageKitTransaction extends DBusObject {
       {DBusSignature? signature}) async {
     switch (name) {
       case 'Role':
-        return DBusGetPropertyResponse(DBusUint32(this.role));
+        return DBusGetPropertyResponse(DBusUint32(role));
       case 'Status':
-        return DBusGetPropertyResponse(DBusUint32(this.status));
+        return DBusGetPropertyResponse(DBusUint32(status));
       case 'LastPackage':
-        return DBusGetPropertyResponse(DBusString(this.lastPackage));
+        return DBusGetPropertyResponse(DBusString(lastPackage));
       case 'Uid':
-        return DBusGetPropertyResponse(DBusUint32(this.uid));
+        return DBusGetPropertyResponse(DBusUint32(uid));
       case 'Percentage':
-        return DBusGetPropertyResponse(DBusUint32(this.percentage));
+        return DBusGetPropertyResponse(DBusUint32(percentage));
       case 'AllowCancel':
-        return DBusGetPropertyResponse(DBusBoolean(this.allowCancel));
+        return DBusGetPropertyResponse(DBusBoolean(allowCancel));
       case 'CallerActive':
-        return DBusGetPropertyResponse(DBusBoolean(this.callerActive));
+        return DBusGetPropertyResponse(DBusBoolean(callerActive));
       case 'ElapsedTime':
-        return DBusGetPropertyResponse(DBusUint32(this.elapsedTime));
+        return DBusGetPropertyResponse(DBusUint32(elapsedTime));
       case 'RemainingTime':
-        return DBusGetPropertyResponse(DBusUint32(this.remainingTime));
+        return DBusGetPropertyResponse(DBusUint32(remainingTime));
       case 'Speed':
-        return DBusGetPropertyResponse(DBusUint32(this.speed));
+        return DBusGetPropertyResponse(DBusUint32(speed));
       case 'DownloadSizeRemaining':
-        return DBusGetPropertyResponse(DBusUint64(this.downloadSizeRemaining));
+        return DBusGetPropertyResponse(DBusUint64(downloadSizeRemaining));
       case 'TransactionFlags':
-        return DBusGetPropertyResponse(DBusUint64(this.transactionFlags));
+        return DBusGetPropertyResponse(DBusUint64(transactionFlags));
       default:
         return DBusMethodErrorResponse.unknownProperty(name);
     }

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -2214,15 +2214,8 @@ void main() {
           PackageKitTransactionFlag.onlyDownload,
         }));
 
-    await t.client!.emitSignal(
-        path: t.path,
-        interface: 'org.freedesktop.DBus.Properties',
-        name: 'PropertiesChanged',
-        values: [
-          DBusString('org.freedesktop.PackageKit.Transaction'),
-          DBusDict.stringVariant({'Percentage': DBusUint32(10)}),
-          DBusArray.string([]),
-        ]);
+    await t.emitPropertiesChanged('org.freedesktop.PackageKit.Transaction',
+        changedProperties: {'Percentage': DBusUint32(10)});
     await expectLater(transaction.propertiesChanged, emits(['Percentage']));
     expect(transaction.percentage, equals(10));
   });

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -2213,5 +2213,17 @@ void main() {
           PackageKitTransactionFlag.simulate,
           PackageKitTransactionFlag.onlyDownload,
         }));
+
+    await t.client!.emitSignal(
+        path: t.path,
+        interface: 'org.freedesktop.DBus.Properties',
+        name: 'PropertiesChanged',
+        values: [
+          DBusString('org.freedesktop.PackageKit.Transaction'),
+          DBusDict.stringVariant({'Percentage': DBusUint32(10)}),
+          DBusArray.string([]),
+        ]);
+    await expectLater(transaction.propertiesChanged, emits(['Percentage']));
+    expect(transaction.percentage, equals(10));
   });
 }

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -65,36 +65,22 @@ class MockPackageKitTransaction extends DBusObject {
       : super(path);
 
   @override
-  Future<DBusMethodResponse> getProperty(String interface, String name,
-      {DBusSignature? signature}) async {
-    switch (name) {
-      case 'Role':
-        return DBusGetPropertyResponse(DBusUint32(role));
-      case 'Status':
-        return DBusGetPropertyResponse(DBusUint32(status));
-      case 'LastPackage':
-        return DBusGetPropertyResponse(DBusString(lastPackage));
-      case 'Uid':
-        return DBusGetPropertyResponse(DBusUint32(uid));
-      case 'Percentage':
-        return DBusGetPropertyResponse(DBusUint32(percentage));
-      case 'AllowCancel':
-        return DBusGetPropertyResponse(DBusBoolean(allowCancel));
-      case 'CallerActive':
-        return DBusGetPropertyResponse(DBusBoolean(callerActive));
-      case 'ElapsedTime':
-        return DBusGetPropertyResponse(DBusUint32(elapsedTime));
-      case 'RemainingTime':
-        return DBusGetPropertyResponse(DBusUint32(remainingTime));
-      case 'Speed':
-        return DBusGetPropertyResponse(DBusUint32(speed));
-      case 'DownloadSizeRemaining':
-        return DBusGetPropertyResponse(DBusUint64(downloadSizeRemaining));
-      case 'TransactionFlags':
-        return DBusGetPropertyResponse(DBusUint64(transactionFlags));
-      default:
-        return DBusMethodErrorResponse.unknownProperty(name);
-    }
+  Future<DBusMethodResponse> getAllProperties(String interface) async {
+    var properties = <String, DBusValue>{
+      'Role': DBusUint32(role),
+      'Status': DBusUint32(status),
+      'LastPackage': DBusString(lastPackage),
+      'Uid': DBusUint32(uid),
+      'Percentage': DBusUint32(percentage),
+      'AllowCancel': DBusBoolean(allowCancel),
+      'CallerActive': DBusBoolean(callerActive),
+      'ElapsedTime': DBusUint32(elapsedTime),
+      'RemainingTime': DBusUint32(remainingTime),
+      'Speed': DBusUint32(speed),
+      'DownloadSizeRemaining': DBusUint64(downloadSizeRemaining),
+      'TransactionFlags': DBusUint64(transactionFlags),
+    };
+    return DBusGetAllPropertiesResponse(properties);
   }
 
   @override
@@ -2203,20 +2189,21 @@ void main() {
     await packagekit.start();
 
     var transaction = PackageKitTransaction(DBusClient(clientAddress), t.path);
+    await transaction.initialized;
 
-    expect(await transaction.getRole(), equals(PackageKitRole.getDetails));
-    expect(await transaction.getStatus(), equals(PackageKitStatus.info));
-    expect(await transaction.getLastPackage(), equals('hal;0.1.2;i386;fedora'));
-    expect(await transaction.getUid(), equals(1000));
-    expect(await transaction.getPercentage(), equals(42));
-    expect(await transaction.getAllowCancel(), equals(true));
-    expect(await transaction.getCallerActive(), equals(false));
-    expect(await transaction.getElapsedTime(), equals(12345));
-    expect(await transaction.getRemainingTime(), equals(54321));
-    expect(await transaction.getSpeed(), equals(299792458));
-    expect(await transaction.getDownloadSizeRemaining(), equals(3000000000));
+    expect(transaction.role, equals(PackageKitRole.getDetails));
+    expect(transaction.status, equals(PackageKitStatus.info));
+    expect(transaction.lastPackage, equals('hal;0.1.2;i386;fedora'));
+    expect(transaction.uid, equals(1000));
+    expect(transaction.percentage, equals(42));
+    expect(transaction.allowCancel, equals(true));
+    expect(transaction.callerActive, equals(false));
+    expect(transaction.elapsedTime, equals(12345));
+    expect(transaction.remainingTime, equals(54321));
+    expect(transaction.speed, equals(299792458));
+    expect(transaction.downloadSizeRemaining, equals(3000000000));
     expect(
-        await transaction.getTransactionFlags(),
+        transaction.transactionFlags,
         equals({
           PackageKitTransactionFlag.onlyTrusted,
           PackageKitTransactionFlag.simulate,


### PR DESCRIPTION
Adds methods to `PackageKitTransaction` that provide access to useful properties.

Maybe it would be nicer to have `PackageKitTransaction` listen to property changes and cache them as `PackageKitClient` does, but I didn't find a simple way to do this without having to call a cleanup method on the transaction that cancels the stream subscription, once the transaction object no longer needed.