### PR TITLE
Add missing transaction flag 'none'

### DIFF
--- a/lib/src/packagekit_client.dart
+++ b/lib/src/packagekit_client.dart
@@ -352,6 +352,7 @@ enum PackageKitStatus {
 
 /// Flags passed to methods on [PackageKitTransaction].
 enum PackageKitTransactionFlag {
+  none,
   onlyTrusted,
   simulate,
   onlyDownload,

--- a/test/packagekit_test.dart
+++ b/test/packagekit_test.dart
@@ -2185,7 +2185,7 @@ void main() {
         remainingTime: 54321,
         speed: 299792458,
         downloadSizeRemaining: 3000000000,
-        transactionFlags: 7);
+        transactionFlags: 14);
     addTearDown(() async => await packagekit.close());
     await packagekit.start();
 


### PR DESCRIPTION
[`PackageKitTransactionFlag.none`](https://github.com/PackageKit/PackageKit/blob/main/lib/packagekit-glib2/pk-enum.h#L780) is currently missing, which means that the values of all other flags are off by one.

I noticed this when testing transactions started with `PackageKitTransactionFlag.simulate`, which didn't work as expected with packagekit.dart, but worked without issues when I manually tried it with d-feet, passing a value of '4'.